### PR TITLE
Update Dockerfile-pip & Readme

### DIFF
--- a/scoring-pipeline-deployment/python/ubuntu/docker/Dockerfile-pip
+++ b/scoring-pipeline-deployment/python/ubuntu/docker/Dockerfile-pip
@@ -4,13 +4,14 @@ FROM ubuntu:bionic
 # No user is created. Installs as root.
 # Use as example code and modify as needed
 
-# These commands run as root 
+# These commands run as root
 # Install base dependencies
-RUN apt-get update && \ 
+RUN apt-get update && \
     apt install -y \
         build-essential \
-        libmagic-dev \ 
+        libmagic-dev \
         libopenblas-dev \
+        openjdk-8-jre \
         git \
         locales \
 	python3-pip \
@@ -26,13 +27,13 @@ ENV HOME /root
 
 WORKDIR $HOME
 
-COPY payload/scorer.zip ./ 
+COPY payload/scorer.zip ./
 COPY payload/license.sig .driverlessai/
 
-RUN unzip scorer.zip 
+RUN unzip scorer.zip
 
 WORKDIR scoring-pipeline
 
-RUN python3 -m pip install --upgrade --upgrade-strategy only-if-needed pip==9.0.3 && \
+RUN python3 -m pip install --upgrade --upgrade-strategy only-if-needed pip==19.3.1 && \
     python3 -m pip install --upgrade --upgrade-strategy only-if-needed -r requirements.txt
 

--- a/scoring-pipeline-deployment/python/ubuntu/docker/README.md
+++ b/scoring-pipeline-deployment/python/ubuntu/docker/README.md
@@ -2,17 +2,17 @@ Python Scoring Pipeline Wrapper using Docker
 ============================================
 
 This directory contains sample code that explains the steps needed to deploy a python scoring pipeline
-obtained from H2O Driverless AI in a Ubuntu 18.04 docker container. This directory acts as the build 
-context for the docker build step. 
+obtained from H2O Driverless AI in a Ubuntu 18.04 docker container. This directory acts as the build
+context for the docker build step.
 
 
 Prerequisites
 -------------
 
 The following pre-requisites are needed
-- [Docker](https://www.docker.com/) 
+- [Docker](https://www.docker.com/)
 
-Follow the installation instructions for your platform and get Docker Ce (or EE) installed on the machine. 
+Follow the installation instructions for your platform and get Docker Ce (or EE) installed on the machine.
 
 
 Code Structure
@@ -36,8 +36,8 @@ Instructions
 3. Change to `top-dir`, which contains the files as mentioned in the above section
 4. Copy the scoring pipeline `scorer.zip` in the `payload` directory. You may need to create the `payload` directory.
 5. Copy Driverless AI license `license.sig` in the `payload` directory
-6. Issue the command `docker build -t scoretest .`. This will
-    - Create a Ubuntu 18.04 based docker container 
+6. Issue the command `docker build -f Dockerfile-pip -t scoretest .`. This will
+    - Create a Ubuntu 18.04 based docker container
     - Install required dependencies, miniconda, python etc..
     - Create a conda environment for the scoring pipeline by installing all needed dependencies
     - Run `example.py` from the scoring pipeline
@@ -48,6 +48,8 @@ shows how to use DAI python scoring pipeline as a python module. There are other
 You can run the docker container in interactive model, and can experiment with the HTTP and TCP endpoints.
 
 Execute the command `docker run -it --rm scoretest:latest`. Once connected you will be in the `scoring-pipeline` directory.
+
+Once inside the Docker container you will need to `chmod +X run_example.sh` to make the sample script executable. Then simply run `bash run_example.sh` to run the example scoring routine.
 
 To run `example.py` you can follow the below steps once you are connected using SSH
 
@@ -63,7 +65,7 @@ Similarly, you can run the HTTP and TCP server python files too.
 Disclaimer
 ----------
 
-The scoring pipeline wrapper code shared in this directory is created to provide you 
+The scoring pipeline wrapper code shared in this directory is created to provide you
 a sample starting point and is not intended to be directly deployed to production as is.
 You can use this starting point and build over it to solve your deployment needs ensuring
 that your security etc. requirements are met.


### PR DESCRIPTION
Updated Dockerfile-pip to include JRE and new PIP version. Readme updated to provide info on running run_example.sh

These changes came about as I was building a DAI 1.9 PY scoring pipeline using the Docker build in these instructions. It failed because of PIP 19.3.1 and Java JRE dependencies. This should fix them.